### PR TITLE
Issuesから言語概説の新規記事を自動作成

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -43,7 +43,7 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
           branch: ${{ env.BRANCH_NAME }}
-          message: add ${{ env.ISO_CODE }}
+          message: add ${{ env.ISO_CODE }} post
           add: ${{ env.POST_PATH }}
 
       - name: Set env var for comment

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -61,5 +61,5 @@ jobs:
             | | Links |
             | :-- | :-- |
             | 🪵 Branch | [`${{ env.BRANCH_NAME }}`](https://github.com/hulinguistics/huling/tree/${{ env.BRANCH_NAME }}) |
-            | ✏ Post | [`${{ env.POST_PATH }}`](https://github.com/hulinguistics/huling/blob/${{ env.BRANCH_NAME }}/${{ env.POST_PATH }}) ([edit](https://github.com/hulinguistics/huling/edit/${{ env.BRANCH_NAME }}/${{ env.POST_PATH }})) |
-            | ☁ Preview | [here](https://${{ env.SUBDOMAIN }}.huling-dev.pages.dev/${{ env.WEB_PATH }}) |
+            | ✏ Post | [`${{ env.POST_PATH }}`](https://github.com/hulinguistics/huling/blob/${{ env.BRANCH_NAME }}/${{ env.POST_PATH }}) ([Edit on Web](https://github.com/hulinguistics/huling/edit/${{ env.BRANCH_NAME }}/${{ env.POST_PATH }})) |
+            | ☁ Preview | [here](https://${{ env.SUBDOMAIN }}.huling-dev.pages.dev/${{ env.WEB_PATH }}) (please wait a few mins) |


### PR DESCRIPTION
<!--
PRありがとうございます✨
-->

Related to #124

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->

Issueのタグから、言語概説の記事の下書きを自動作成します。

Issueにタイトルを言語名のみにして、`🍃newlangpost`のタグをつけることで、WikipediaからISO 639-3のコードと原語での言語名を取得し、[テンプレート](https://github.com/hulinguistics/huling/blob/dev/archetypes/docs/lang/index.md)を基に空白の記事が作成されます。また、新しいブランチを作成してそのブランチとWebUIでの編集画面のURLがIssueにコメントされます。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->

記事の作成をWebUIだけで済むようにすることで、みんなが記事を追加できるようにする

# Additional info (optional)
<!-- テスト観点など -->

オリンピック問題解説でも同様の機能を実装したい。