### PR TITLE
古代教会スラヴ語関連の文字のフォントを追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "DavidAnson.vscode-markdownlint"
+    "davidanson.vscode-markdownlint",
+    "rvest.vs-code-prettier-eslint"
   ]
 }

--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -70,11 +70,11 @@ export default {
       type: String,
       default: null,
     },
-    font_left: {
+    fontLeft: {
       type: String,
       default: 'Source Code Pro',
     },
-    font_right: {
+    fontRight: {
       type: String,
       default: 'Source Code Pro',
     },
@@ -152,16 +152,10 @@ export default {
       { deep: true },
     );
 
-    // フォント出力
-    const font_left = props.font_left;
-    const font_right = props.font_right;
-
     return {
       status,
       list,
       textarea,
-      font_left,
-      font_right,
     };
   },
 };
@@ -202,11 +196,11 @@ export default {
         border-color: var(--vp-custom-block-details-border);
 
         &#leftta {
-          font-family: v-bind(font_left), 'Source Code Pro', monospace;
+          font-family: v-bind(fontLeft), 'Source Code Pro', monospace;
         }
 
         &#rightta {
-          font-family: v-bind(font_right), 'Source Code Pro', monospace;
+          font-family: v-bind(fontRight), 'Source Code Pro', monospace;
         }
       }
     }

--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -70,9 +70,13 @@ export default {
       type: String,
       default: null,
     },
-    csv: {
+    font_left: {
       type: String,
-      default: '',
+      default: 'Source Code Pro',
+    },
+    font_right: {
+      type: String,
+      default: 'Source Code Pro',
     },
   },
 
@@ -148,16 +152,23 @@ export default {
       { deep: true },
     );
 
+    // フォント出力
+    const font_left = props.font_left;
+    const font_right = props.font_right;
+
     return {
       status,
       list,
       textarea,
+      font_left,
+      font_right,
     };
   },
 };
 </script>
 
 <style lang="scss" scoped>
+// Source Code Pro
 @import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap');
 
 .HLConverter {
@@ -184,12 +195,19 @@ export default {
         min-height: 200px;
         padding: 15px;
         font-size: 1em;
-        font-family: 'Source Code Pro', monospace;
         line-height: 1.6;
         background-color: var(--vp-c-bg-alt);
         border: 1px solid transparent;
         border-radius: 8px;
         border-color: var(--vp-custom-block-details-border);
+
+        &#leftta {
+          font-family: v-bind(font_left), 'Source Code Pro', monospace;
+        }
+
+        &#rightta {
+          font-family: v-bind(font_right), 'Source Code Pro', monospace;
+        }
       }
     }
   }

--- a/src/.vitepress/theme/scss/font.scss
+++ b/src/.vitepress/theme/scss/font.scss
@@ -3,7 +3,6 @@
     sans-serif;
 }
 
-// Noto Sans
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
@@ -28,7 +27,6 @@
   src: url('/font/NotoSans-SemiBold.woff2') format('woff2');
 }
 
-// Noto Sans JP
 @font-face {
   font-family: 'Noto Sans JP';
   font-style: normal;

--- a/src/.vitepress/theme/scss/font.scss
+++ b/src/.vitepress/theme/scss/font.scss
@@ -3,6 +3,7 @@
     sans-serif;
 }
 
+// Noto Sans
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
@@ -27,6 +28,7 @@
   src: url('/font/NotoSans-SemiBold.woff2') format('woff2');
 }
 
+// Noto Sans JP
 @font-face {
   font-family: 'Noto Sans JP';
   font-style: normal;
@@ -41,4 +43,17 @@
   font-weight: 700;
   font-display: swap;
   src: url('/font/NotoSansCJKjp-Bold.woff2') format('woff2');
+}
+
+// Monomakh Unicode
+@font-face {
+  font-family: 'Monomakh Unicode';
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+  src: url('https://sci.ponomar.net/fonts/MonomakhUnicode.eot');
+  src: url('https://sci.ponomar.net/fonts/MonomakhUnicode.eot?#iefix') format('embedded-opentype'),
+    url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff2') format('woff2'),
+    url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff') format('woff'),
+    url('https://sci.ponomar.net/fonts/MonomakhUnicode.ttf') format('truetype');
 }

--- a/src/.vitepress/theme/scss/font.scss
+++ b/src/.vitepress/theme/scss/font.scss
@@ -44,29 +44,3 @@
   font-display: swap;
   src: url('/font/NotoSansCJKjp-Bold.woff2') format('woff2');
 }
-
-// Monomakh Unicode
-@font-face {
-  font-family: 'Monomakh Unicode';
-  font-style: normal;
-  font-weight: normal;
-  font-display: swap;
-  src: url('https://sci.ponomar.net/fonts/MonomakhUnicode.eot');
-  src: url('https://sci.ponomar.net/fonts/MonomakhUnicode.eot?#iefix') format('embedded-opentype'),
-    url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff2') format('woff2'),
-    url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff') format('woff'),
-    url('https://sci.ponomar.net/fonts/MonomakhUnicode.ttf') format('truetype');
-}
-
-// Shafarik
-@font-face {
-  font-family: 'Shafarik';
-  font-style: normal;
-  font-weight: normal;
-  font-display: swap;
-  src: url('https://sci.ponomar.net/fonts/Shafarik-Regular.eot');
-  src: url('https://sci.ponomar.net/fonts/Shafarik-Regular.eot?#iefix') format('embedded-opentype'),
-    url('https://sci.ponomar.net/fonts/Shafarik-Regular.woff2') format('woff2'),
-    url('https://sci.ponomar.net/fonts/Shafarik-Regular.woff') format('woff'),
-    url('https://sci.ponomar.net/fonts/Shafarik-Regular.ttf') format('truetype');
-}

--- a/src/.vitepress/theme/scss/font.scss
+++ b/src/.vitepress/theme/scss/font.scss
@@ -57,3 +57,16 @@
     url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff') format('woff'),
     url('https://sci.ponomar.net/fonts/MonomakhUnicode.ttf') format('truetype');
 }
+
+// Shafarik
+@font-face {
+  font-family: 'Shafarik';
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+  src: url('https://sci.ponomar.net/fonts/Shafarik-Regular.eot');
+  src: url('https://sci.ponomar.net/fonts/Shafarik-Regular.eot?#iefix') format('embedded-opentype'),
+    url('https://sci.ponomar.net/fonts/Shafarik-Regular.woff2') format('woff2'),
+    url('https://sci.ponomar.net/fonts/Shafarik-Regular.woff') format('woff'),
+    url('https://sci.ponomar.net/fonts/Shafarik-Regular.ttf') format('truetype');
+}

--- a/src/.vitepress/theme/scss/index.scss
+++ b/src/.vitepress/theme/scss/index.scss
@@ -14,3 +14,33 @@
   --vp-c-brand-dark: var(--vp-c-blue-dark);
   --vp-c-brand-darker: var(--vp-c-blue-darker);
 }
+
+//
+// Fonts
+//
+
+// Monomakh Unicode
+@font-face {
+  font-family: 'Monomakh Unicode';
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+  src: url('https://sci.ponomar.net/fonts/MonomakhUnicode.eot');
+  src: url('https://sci.ponomar.net/fonts/MonomakhUnicode.eot?#iefix') format('embedded-opentype'),
+    url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff2') format('woff2'),
+    url('https://sci.ponomar.net/fonts/MonomakhUnicode.woff') format('woff'),
+    url('https://sci.ponomar.net/fonts/MonomakhUnicode.ttf') format('truetype');
+}
+
+// Shafarik
+@font-face {
+  font-family: 'Shafarik';
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+  src: url('https://sci.ponomar.net/fonts/Shafarik-Regular.eot');
+  src: url('https://sci.ponomar.net/fonts/Shafarik-Regular.eot?#iefix') format('embedded-opentype'),
+    url('https://sci.ponomar.net/fonts/Shafarik-Regular.woff2') format('woff2'),
+    url('https://sci.ponomar.net/fonts/Shafarik-Regular.woff') format('woff'),
+    url('https://sci.ponomar.net/fonts/Shafarik-Regular.ttf') format('truetype');
+}

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -25,7 +25,7 @@ commentHide: true
 ### 古代教会スラヴ語キリル文字
 
 <!-- markdownlint-disable MD033 -->
-<HLConverter src="/conv/chu.csv" />
+<HLConverter src="/conv/chu.csv" font_right="Monomakh Unicode" />
 <!-- markdownlint-enable MD033 -->
 
 ### アイヌ語仮名

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -25,7 +25,7 @@ commentHide: true
 ### 古代教会スラヴ語キリル文字
 
 <!-- markdownlint-disable MD033 -->
-<HLConverter src="/conv/chu.csv" font_right="Monomakh Unicode" />
+<HLConverter src="/conv/chu.csv" fontRight="Monomakh Unicode" />
 <!-- markdownlint-enable MD033 -->
 
 ### アイヌ語仮名


### PR DESCRIPTION
<!--
PRありがとうございます✨
-->

solve #197

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->

古代教会スラヴ語関連のフォント "Shafarik", "Monomakh Unicode" ([公式サイト](https://sci.ponomar.net/fonts.html)) を追加した．また，変換器でフォントを指定できるようにし，すでに存在する古代教会スラヴ語の変換器については "Monomakh Unicode" を適用した．

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->

#197

# Additional info (optional)
<!-- テスト観点など -->

普通の記事中の文章については `span` タグなどで適用可能だが，毎回markdownlint MD033を切る必要があり不恰好．別の方法にしたい．