### PR TITLE
SourceフォントをやめてNotoフォントにする

### DIFF
--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -169,9 +169,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-// Source Code Pro
-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap');
-
 .HLConverter {
   margin: 16px 0;
 

--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -203,12 +203,12 @@ export default {
   }
 
   [leftta] {
-    font-family: v-bind(fontLeft), 'Source Code Pro', monospace;
+    font-family: v-bind(fontLeft), 'Noto Sans Mono', monospace;
     direction: v-bind(dirLeft);
   }
 
   [rightta] {
-    font-family: v-bind(fontRight), 'Source Code Pro', monospace;
+    font-family: v-bind(fontRight), 'Noto Sans Mono', monospace;
     direction: v-bind(dirRight);
   }
 }

--- a/src/.vitepress/theme/font.config.json
+++ b/src/.vitepress/theme/font.config.json
@@ -1,7 +1,7 @@
 {
   "root_family": [
-    "Noto Sans",
-    "Noto Sans JP",
+    "Source Sans",
+    "Source Han Sans Japanese",
     "Helvetica Neue",
     "Arial",
     "Hiragino Kaku Gothic ProN",
@@ -11,40 +11,28 @@
   ],
   "subsets": [
     {
-      "name": "Noto Sans",
+      "name": "Source Sans",
       "fonts": [
         {
-          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf",
+          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-Regular.ttf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Italic.ttf",
+          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-It.ttf",
           "style": "italic",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Medium.ttf",
-          "style": "normal",
-          "weight": 500,
-          "display": "swap"
-        },
-        {
-          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-MediumItalic.ttf",
-          "style": "italic",
-          "weight": 500,
-          "display": "swap"
-        },
-        {
-          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-SemiBold.ttf",
+          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-Semibold.ttf",
           "style": "normal",
           "weight": 600,
           "display": "swap"
         },
         {
-          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-SemiBoldItalic.ttf",
+          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-SemiboldIt.ttf",
           "style": "italic",
           "weight": 600,
           "display": "swap"
@@ -52,16 +40,27 @@
       ]
     },
     {
-      "name": "Noto Sans JP",
+      "name": "Source Code Pro",
       "fonts": [
         {
-          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf",
+          "src": "https://github.com/adobe-fonts/source-code-pro/raw/release/TTF/SourceCodePro-Regular.ttf",
+          "style": "normal",
+          "weight": 400,
+          "display": "swap"
+        }
+      ]
+    },
+    {
+      "name": "Source Han Sans Japanese",
+      "fonts": [
+        {
+          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/Japanese/SourceHanSans-Regular.otf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf",
+          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/Japanese/SourceHanSans-Bold.otf",
           "style": "normal",
           "weight": 700,
           "display": "swap"
@@ -69,17 +68,17 @@
       ]
     },
     {
-      "name": "Noto Sans SC",
+      "name": "Source Han Sans SimplifiedChinese",
       "tag": "hans",
       "fonts": [
         {
-          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf",
+          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SimplifiedChinese/SourceHanSansSC-Regular.otf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf",
+          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SimplifiedChinese/SourceHanSansSC-Bold.otf",
           "style": "normal",
           "weight": 700,
           "display": "swap"
@@ -87,19 +86,31 @@
       ]
     },
     {
-      "name": "Noto Sans TC",
+      "name": "Source Han Sans TraditionalChinese",
       "tag": "hant",
       "fonts": [
         {
-          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf",
+          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/TraditionalChinese/SourceHanSansTC-Regular.otf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf",
+          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/TraditionalChinese/SourceHanSansTC-Bold.otf",
           "style": "normal",
           "weight": 700,
+          "display": "swap"
+        }
+      ]
+    },
+    {
+      "name": "Source Hebrew Sans",
+      "tag": "hebr",
+      "fonts": [
+        {
+          "src": "https://github.com/adobe-fonts/source-hebrew-sans/raw/master/Upright/Regular/SourceHebrewSans-Regular.otf",
+          "style": "normal",
+          "weight": 400,
           "display": "swap"
         }
       ]

--- a/src/.vitepress/theme/font.config.json
+++ b/src/.vitepress/theme/font.config.json
@@ -1,7 +1,7 @@
 {
   "root_family": [
-    "Source Sans",
-    "Source Han Sans Japanese",
+    "Noto Sans",
+    "Noto Sans JP",
     "Helvetica Neue",
     "Arial",
     "Hiragino Kaku Gothic ProN",
@@ -11,39 +11,45 @@
   ],
   "subsets": [
     {
-      "name": "Source Sans",
+      "name": "Noto Sans",
       "fonts": [
         {
-          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-Regular.ttf",
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Regular.ttf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-It.ttf",
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Italic.ttf",
           "style": "italic",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-Semibold.ttf",
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-Medium.ttf",
           "style": "normal",
-          "weight": 600,
+          "weight": 500,
           "display": "swap"
         },
         {
-          "src": "https://github.com/adobe-fonts/source-sans/raw/release/TTF/SourceSans3-SemiboldIt.ttf",
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-MediumItalic.ttf",
           "style": "italic",
+          "weight": 500,
+          "display": "swap"
+        },
+        {
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSans/NotoSans-SemiBold.ttf",
+          "style": "normal",
           "weight": 600,
           "display": "swap"
         }
       ]
     },
     {
-      "name": "Source Code Pro",
+      "name": "Noto Sans Mono",
       "fonts": [
         {
-          "src": "https://github.com/adobe-fonts/source-code-pro/raw/release/TTF/SourceCodePro-Regular.ttf",
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSansMono/NotoSansMono-Regular.ttf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
@@ -51,16 +57,16 @@
       ]
     },
     {
-      "name": "Source Han Sans Japanese",
+      "name": "Noto Sans JP",
       "fonts": [
         {
-          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/Japanese/SourceHanSans-Regular.otf",
+          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/Japanese/SourceHanSans-Bold.otf",
+          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf",
           "style": "normal",
           "weight": 700,
           "display": "swap"
@@ -68,17 +74,17 @@
       ]
     },
     {
-      "name": "Source Han Sans SimplifiedChinese",
+      "name": "Noto Sans SC",
       "tag": "hans",
       "fonts": [
         {
-          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SimplifiedChinese/SourceHanSansSC-Regular.otf",
+          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/SimplifiedChinese/SourceHanSansSC-Bold.otf",
+          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Bold.otf",
           "style": "normal",
           "weight": 700,
           "display": "swap"
@@ -86,17 +92,17 @@
       ]
     },
     {
-      "name": "Source Han Sans TraditionalChinese",
+      "name": "Noto Sans TC",
       "tag": "hant",
       "fonts": [
         {
-          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/TraditionalChinese/SourceHanSansTC-Regular.otf",
+          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Regular.otf",
           "style": "normal",
           "weight": 400,
           "display": "swap"
         },
         {
-          "src": "https://github.com/adobe-fonts/source-han-sans/raw/release/OTF/TraditionalChinese/SourceHanSansTC-Bold.otf",
+          "src": "https://github.com/googlefonts/noto-cjk/raw/main/Sans/OTF/TraditionalChinese/NotoSansCJKtc-Bold.otf",
           "style": "normal",
           "weight": 700,
           "display": "swap"
@@ -104,11 +110,11 @@
       ]
     },
     {
-      "name": "Source Hebrew Sans",
+      "name": "Noto Sans Hebrew",
       "tag": "hebr",
       "fonts": [
         {
-          "src": "https://github.com/adobe-fonts/source-hebrew-sans/raw/master/Upright/Regular/SourceHebrewSans-Regular.otf",
+          "src": "https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/NotoSansHebrew/NotoSansHebrew-Regular.ttf",
           "style": "normal",
           "weight": 400,
           "display": "swap"

--- a/src/docs/tools/conv/index.md
+++ b/src/docs/tools/conv/index.md
@@ -307,7 +307,7 @@ f(:S:),g(:S:)
 「תּ」`*t`．
 ラテン文字は語頭も小文字で入力すること．
 
-<HLConverter src="/conv/yid.tsv" dirRight="rtl" fontRight="Source Hebrew Sans" />
+<HLConverter src="/conv/yid.tsv" dirRight="rtl" fontRight="Noto Sans Hebrew" />
 
 ## アイヌ語カタカナ
 

--- a/src/docs/tools/conv/index.md
+++ b/src/docs/tools/conv/index.md
@@ -314,7 +314,7 @@ f(:S:),g(:S:)
 北海道アイヌ語、樺太アイヌ語対応．
 喉頭破裂音は `'`．
 
-<HLConverter src="/conv/ain.tsv" />
+<HLConverter src="/conv/ain.tsv" fontRight="Noto Sans JP" />
 
 ::: details 変換表
 

--- a/src/docs/tools/conv/index.md
+++ b/src/docs/tools/conv/index.md
@@ -307,7 +307,7 @@ f(:S:),g(:S:)
 「תּ」`*t`．
 ラテン文字は語頭も小文字で入力すること．
 
-<HLConverter src="/conv/yid.tsv" dirRight="rtl"  />
+<HLConverter src="/conv/yid.tsv" dirRight="rtl" fontRight="Source Hebrew Sans" />
 
 ## アイヌ語カタカナ
 


### PR DESCRIPTION
<!--
PRありがとうございます✨
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->

仕様するフォントをNotoに統一(古教会スラヴ語関連以外)
ヘブライ文字フォントを追加

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->

Source Code Proだと表示できない合字があるため
また，Source Sansだとweight 500に相当するフォントがなく，navのフォントが細くなってしまうため，Notoに統一した

# Additional info (optional)
<!-- テスト観点など -->
