### PR TITLE
文字変換器: デザイン修正

### DIFF
--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -1,65 +1,57 @@
 <template>
   <div class="HLConverter">
-    <div v-if="status.loading">
-      <p>Now loading...</p>
+    <div class="convbox">
+      <label>
+        <header>{{ status.loading ? 'Now loading...' : status.error ? 'ERROR' : list.title.left }}</header>
+        <textarea
+          v-model="textarea.left.value"
+          cols="20"
+          rows="10"
+          leftta
+          :readonly="!!status.loading || !!status.error"
+          @focus="textarea.left.isFocus = true"
+          @blur="textarea.left.isFocus = false"
+        ></textarea>
+      </label>
+      <label>
+        <header>{{ status.loading ? 'Now loading...' : status.error ? 'ERROR' : list.title.right }}</header>
+        <textarea
+          v-model="textarea.right.value"
+          cols="20"
+          rows="10"
+          rightta
+          :readonly="!!status.loading || !!status.error"
+          @focus="textarea.right.isFocus = true"
+          @blur="textarea.right.isFocus = false"
+        ></textarea>
+      </label>
     </div>
-    <div v-else-if="status.error" class="danger custom-block">
-      <p class="custom-block-title">ERROR</p>
-      <p>{{ status.error }}</p>
-    </div>
-    <div v-else>
-      <div class="convbox">
-        <div>
-          <label>
-            <header>{{ list.title.left }}</header>
-            <textarea
-              v-model="textarea.left.value"
-              cols="20"
-              rows="10"
-              leftta
-              @focus="textarea.left.isFocus = true"
-              @blur="textarea.left.isFocus = false"
-            ></textarea>
-            </label>
-        </div>
-        <div>
-          <label>
-            <header>{{ list.title.right }}</header>
-            <textarea
-              v-model="textarea.right.value"
-              cols="20"
-              rows="10"
-              rightta
-              @focus="textarea.right.isFocus = true"
-              @blur="textarea.right.isFocus = false"
-            ></textarea>
-          </label>
-        </div>
+    <details class="details custom-block">
+      <summary>{{ status.loading ? 'Now loading...' : status.error ? 'ERROR' : '優先順' }}</summary>
+      <table v-if="!status.loading && !status.error">
+        <thead>
+          <tr>
+            <th style="text-align: center">優先順</th>
+            <th style="text-align: center">{{ list.title.left }}</th>
+            <th style="text-align: center">{{ list.title.right }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(column, index) in list.set" :key="index">
+            <td style="text-align: center">{{ index + 1 }}</td>
+            <td style="text-align: center">
+              <code leftta>{{ column[0] }}</code>
+            </td>
+            <td style="text-align: center">
+              <code rightta>{{ column[1] }}</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div v-if="status.error" class="language-txt">
+        <pre class="shiki"><code><span class="line"><span style="color:#A6ACCD;">{{ status.error }}</span></span></code></pre>
       </div>
-      <details class="details custom-block">
-        <summary>優先順</summary>
-        <table>
-          <thead>
-            <tr>
-              <th style="text-align: center">優先順</th>
-              <th style="text-align: center">{{ list.title.left }}</th>
-              <th style="text-align: center">{{ list.title.right }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(column, index) in list.set" :key="index">
-              <td style="text-align: center">{{ index + 1 }}</td>
-              <td style="text-align: center">
-                <code leftta>{{ column[0] }}</code>
-              </td>
-              <td style="text-align: center">
-                <code rightta>{{ column[1] }}</code>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </details>
-    </div>
+    </details>
   </div>
 </template>
 
@@ -179,7 +171,7 @@ export default {
     grid-template-columns: 1fr 1fr;
     gap: 16px;
 
-    div label {
+    label {
       header {
         display: inline-block;
         width: 100%;

--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -68,11 +68,11 @@ export default {
     },
     fontLeft: {
       type: String,
-      default: 'Source Code Pro',
+      default: 'Noto Sans Mono',
     },
     fontRight: {
       type: String,
-      default: 'Source Code Pro',
+      default: 'Noto Sans Mono',
     },
     dirLeft: {
       type: String,
@@ -197,12 +197,12 @@ export default {
   }
 
   [leftta] {
-    font-family: v-bind(fontLeft), 'Noto Sans Mono', monospace;
+    font-family: v-bind(fontLeft), monospace;
     direction: v-bind(dirLeft);
   }
 
   [rightta] {
-    font-family: v-bind(fontRight), 'Noto Sans Mono', monospace;
+    font-family: v-bind(fontRight), monospace;
     direction: v-bind(dirRight);
   }
 }

--- a/src/.vitepress/theme/components/HLConverter.vue
+++ b/src/.vitepress/theme/components/HLConverter.vue
@@ -10,28 +10,30 @@
     <div v-else>
       <div class="convbox">
         <div>
-          <label for="leftta">{{ list.title.left }}</label>
-          <textarea
-            id="leftta"
-            v-model="textarea.left.value"
-            cols="20"
-            rows="10"
-            leftta
-            @focus="textarea.left.isFocus = true"
-            @blur="textarea.left.isFocus = false"
-          ></textarea>
+          <label>
+            <header>{{ list.title.left }}</header>
+            <textarea
+              v-model="textarea.left.value"
+              cols="20"
+              rows="10"
+              leftta
+              @focus="textarea.left.isFocus = true"
+              @blur="textarea.left.isFocus = false"
+            ></textarea>
+            </label>
         </div>
         <div>
-          <label for="rightta">{{ list.title.right }}</label>
-          <textarea
-            id="rightta"
-            v-model="textarea.right.value"
-            cols="20"
-            rows="10"
-            rightta
-            @focus="textarea.right.isFocus = true"
-            @blur="textarea.right.isFocus = false"
-          ></textarea>
+          <label>
+            <header>{{ list.title.right }}</header>
+            <textarea
+              v-model="textarea.right.value"
+              cols="20"
+              rows="10"
+              rightta
+              @focus="textarea.right.isFocus = true"
+              @blur="textarea.right.isFocus = false"
+            ></textarea>
+          </label>
         </div>
       </div>
       <details class="details custom-block">
@@ -177,8 +179,8 @@ export default {
     grid-template-columns: 1fr 1fr;
     gap: 16px;
 
-    div {
-      label {
+    div label {
+      header {
         display: inline-block;
         width: 100%;
         font-size: 1.1em;

--- a/src/docs/tools/conv/index.md
+++ b/src/docs/tools/conv/index.md
@@ -19,7 +19,7 @@ section: 便利機能
 アクセント記号は母音字の直後に `/` を入れてください (`//` で第2アクセント).
 1918年の正書法改革以前に使用されていた文字 ѣ, і, ѵ, ѳ はそれぞれ `e_`, `i_`, `i__`, `f_`.  
 
-<HLConverter src="/conv/rus.tsv" />
+<HLConverter src="/conv/rus.atsv" />
 
 ::: details 対応表
 

--- a/src/docs/tools/conv/index.md
+++ b/src/docs/tools/conv/index.md
@@ -19,7 +19,7 @@ section: 便利機能
 アクセント記号は母音字の直後に `/` を入れてください (`//` で第2アクセント).
 1918年の正書法改革以前に使用されていた文字 ѣ, і, ѵ, ѳ はそれぞれ `e_`, `i_`, `i__`, `f_`.  
 
-<HLConverter src="/conv/rus.atsv" />
+<HLConverter src="/conv/rus.tsv" />
 
 ::: details 対応表
 


### PR DESCRIPTION
<!--
PRありがとうございます✨
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->

文字変換器のデザインを修正した
文字変換器読み込み中やエラー時はこれまでは `textarea` を隠していたが，常に表示するようにした．これによってページ遷移後のスクロール時に別の場所になることは無いと思われる．ついでにいくつかのバグを修正した．

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->

#293 

# Additional info (optional)
<!-- テスト観点など -->

動作確認 : [コプト文字変換器のリンク](https://293-scroll.huling-dev.pages.dev/docs/tools/conv/#%E3%82%B3%E3%83%95%E3%82%9A%E3%83%88%E8%AA%9E%E3%82%B3%E3%83%95%E3%82%9A%E3%83%88%E6%96%87%E5%AD%97)
